### PR TITLE
Pass over include.txt

### DIFF
--- a/scripts/subsample.py
+++ b/scripts/subsample.py
@@ -48,7 +48,7 @@ def register_arguments(parser):
         help="reference (which was used for alignment)",
     )
     parser.add_argument(
-        "--include-strains-file",
+        "--include",
         required=False,
         nargs="+",
         default=None,
@@ -56,7 +56,7 @@ def register_arguments(parser):
         help="strains to force include",
     )
     parser.add_argument(
-        "--exclude-strains-file",
+        "--exclude",
         required=False,
         nargs="+",
         default=None,

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -76,7 +76,7 @@ rule subsample:
             --reference {input.reference} \
             --alignment {input.sequences} \
             --metadata {input.metadata} \
-            --include-strains-file {input.include} \
+            --include {input.include} \
             --output-fasta {output.sequences} \
             --output-metadata {output.metadata} \
             --output-log {output.log} \


### PR DESCRIPTION
The `include.txt` is not passed over to `augur filter`. This is all arguments `augur filter` received in a run and it's missing `--include`.
![image](https://user-images.githubusercontent.com/20667188/213031383-80213bb2-bd97-4346-a995-046b426cbf26.png)

It works if I add `include: ` to subsampling but that breaks how yaml builder works. 
<img width="366" alt="image" src="https://user-images.githubusercontent.com/20667188/213031604-9d9e67af-2b75-4b8c-af8e-e8ce7ebd996c.png">

I do not fully understand how `subsample.py` passes arguments from `core.smk` into `augur filter` so I couldn't quite fix this 😞 The edits below is what I tried but didn't work.